### PR TITLE
サービスセクション画像切り替え

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -72,13 +72,14 @@ $(function(){
 });
 
 $(function(){
-    $('.service-img').mouseover(function(){
+    $('.service-img').hover(function(){
         console.log('マウスオーバー！');
-        $('.service-img').children('img').attr('src', "{{ asset('/images/web製作.png') }}")
-
-        // $('service-img img').pixelate({
-        //     value: 0.05,
-        //     reveal:true
-        // })
-    })
+        const Src = $(this).children('img').attr('src');
+        console.log(Src);
+        $(this).children('img').attr('src', "/images/web製作.png");
+    }, function() {
+        console.log('マウスリーブ！');
+        $(this).children('img').attr('src', this.Src);
+    }
+    )
 });


### PR DESCRIPTION
画像切り替え成功　しかし戻すことができない
元のイメージタグのsrcを保持して、マウスリーブしたときに再度呼び出すようにしたいが、うまくいかない
参照渡しになっているので、マウスオーバーしたときにSrcが書き換わっている様子

クラス名分けて、それぞれ画像のリンクを固定値で持たせるとうまくいくと思われるが
共通で使用する方向で検討中